### PR TITLE
Allow passing block number in list-by-prefix queries

### DIFF
--- a/src/processor/handler.rs
+++ b/src/processor/handler.rs
@@ -272,6 +272,7 @@ pub trait TransactionContext {
 
     fn get_state_entries_by_prefix(
         &self,
+        tip_id: &str,
         address: &str,
     ) -> Result<Vec<(String, Vec<u8>)>, ContextError>;
 }

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -160,7 +160,9 @@ impl TransactionContext for EmptyTransactionContext {
         tip_id: &str,
         address: &str,
     ) -> Result<Vec<(String, Vec<u8>)>, handler::ContextError> {
-        self.inner.context.get_state_entries_by_prefix(tip_id, address)
+        self.inner
+            .context
+            .get_state_entries_by_prefix(tip_id, address)
     }
 }
 

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -157,9 +157,10 @@ impl TransactionContext for EmptyTransactionContext {
 
     fn get_state_entries_by_prefix(
         &self,
+        tip_id: &str,
         address: &str,
     ) -> Result<Vec<(String, Vec<u8>)>, handler::ContextError> {
-        self.inner.context.get_state_entries_by_prefix(address)
+        self.inner.context.get_state_entries_by_prefix(tip_id, address)
     }
 }
 

--- a/src/processor/zmq_context.rs
+++ b/src/processor/zmq_context.rs
@@ -380,10 +380,11 @@ impl TransactionContext for ZmqTransactionContext {
 
     fn get_state_entries_by_prefix(
         &self,
+        tip_id: &str,
         address: &str,
     ) -> Result<Vec<(String, Vec<u8>)>, ContextError> {
         let mut start = String::new();
-        let mut root = String::new();
+        let mut root: String = tip_id.into();
 
         let mut entries = Vec::new();
 
@@ -392,7 +393,10 @@ impl TransactionContext for ZmqTransactionContext {
 
             request.set_state_root(root.clone());
             request.mut_paging().set_start(start.clone());
-            request.mut_paging().set_limit(100);
+
+            //no need to set paging limit explicitely, the default one should work fine or better
+            //request.mut_paging().set_limit(100);
+
             request.set_address(address.into());
 
             let serialized = request.write_to_bytes()?;


### PR DESCRIPTION
To fix block verification in sawtooth 1.2 - the following PRs are all related and should be reviewed and merged together:
CRB-236/sdk-accepts-block-num-for-list-by-prefix
CRB-236/validator-fixes-block-verification
CRB-236/tp-fixes-block-verification
CRB-236/core-updating-tx-version
