### PR TITLE
CRB-165: Enable dependency updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+
+  # Maintain dependencies for Rust
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Note: I'm not sure if Dependabot will find all Cargo.toml files in the various directories. I guess we just need to give it a try.

Note2: since this repository is a fork this service may need to be explicitly enabled from repo settings after merging this PR.