### PR TITLE
CRB-275 Conditionally include tracing-zmq-logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ documentation = "https://sawtooth.hyperledger.org/docs/core/releases/latest/"
 edition = "2018"
 
 [features]
-default = ["pem"]
+default = ["pem", "log-zmq-stream"]
 
 stable = ["default"]
 
@@ -42,6 +42,7 @@ vendored-zmq = ["zmq/vendored"]
 vendored-openssl = ["openssl/vendored"]
 
 old-sawtooth = []
+log-zmq-stream = []
 
 [dependencies]
 hex = "0.4"

--- a/src/messaging/zmq_stream.rs
+++ b/src/messaging/zmq_stream.rs
@@ -262,11 +262,13 @@ impl SendReceiveStream {
             ];
             zmq::poll(&mut poll_items, POLL_TIMEOUT).unwrap();
             if poll_items[0].is_readable() {
+                #[cfg(feature = "log-zmq-stream")]
                 trace!("Readable!");
                 let mut received_parts = self.socket.recv_multipart(0).unwrap();
 
                 // Grab the last part, which should contain our message
                 if let Some(received_bytes) = received_parts.pop() {
+                    #[cfg(feature = "log-zmq-stream")]
                     trace!("Received {} bytes", received_bytes.len());
                     if !received_bytes.is_empty() {
                         let message = protobuf::Message::parse_from_bytes(&received_bytes).unwrap();
@@ -290,6 +292,7 @@ impl SendReceiveStream {
             {
                 Ok(SocketCommand::Send(msg)) => {
                     let message_bytes = protobuf::Message::write_to_bytes(&msg).unwrap();
+                    #[cfg(feature = "log-zmq-stream")]
                     trace!("Sending {} bytes", message_bytes.len());
                     self.socket.send(&message_bytes, 0).unwrap();
                 }


### PR DESCRIPTION
Consider this, and opting out the feature to reduce log files size in your debugging builds.